### PR TITLE
Use an alarm timer and monotonic timekeeping

### DIFF
--- a/perlpv
+++ b/perlpv
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 
-use Time::HiRes;
+use Time::HiRes qw(clock_gettime CLOCK_MONOTONIC);
 
 # We need to turn off buffering of STDOUT to get rapid display of progress.
 STDOUT->autoflush(1);
@@ -18,7 +18,7 @@ my $TARGET = $ARGV[1];
 #                                 does appear SLIGHTLY faster, at least for the inital couple of seconds, than using 64KiB.
 my $blocksize = 1024 * 1024;   
 
-my $begin = Time::HiRes::time;
+my $begin = monotime;
 
 	my $size = open_files($SOURCE, $TARGET, $blocksize);
 
@@ -26,10 +26,13 @@ my $begin = Time::HiRes::time;
 
 	close_files($SOURCE, $TARGET);
 
-my $end = Time::HiRes::time;
+my $end = monotime;
 
 exit 0;
 
+sub monotime {
+	clock_gettime(CLOCK_MONOTONIC)
+}
 
 sub transfer_data {
 	my $source_size = shift;
@@ -38,8 +41,8 @@ sub transfer_data {
 	my $returncode = 1;
 
 	my $total_bytes_read=0;
-	my $begin = Time::HiRes::time;
-	my $last_printed = Time::HiRes::time;
+	my $begin = monotime;
+	my $last_printed = monotime;
 
 	# We need to keep a running tally of point-in-time transfer rates for improved accuracy
 	# in progress bar completion estimates.
@@ -50,7 +53,7 @@ sub transfer_data {
 
 	while ($returncode ne 0) {
 		# note the time before reading each source block
-		my $timestamp_before_reading = Time::HiRes::time;
+		my $timestamp_before_reading = monotime;
 
 		$returncode = sysread (SOURCE, my $buffer, $blocksize);
 		$current_bytes_read = length($buffer);
@@ -61,7 +64,7 @@ sub transfer_data {
 			: "Exit status $? from $TARGET";
 		
 		# note the time after successfully writing each block
-		my $timestamp_after_writing = Time::HiRes::time;
+		my $timestamp_after_writing = monotime;
 
 		# calculate transfer rate of this block
 		my $current_time_elapsed = $timestamp_after_writing - $timestamp_before_reading;
@@ -75,11 +78,11 @@ sub transfer_data {
 			my $time_elapsed = $timestamp_after_writing - $begin;
 			
 			display_progress ($total_bytes_read, $source_size, $time_elapsed, \@rate_history);
-			$last_printed = Time::HiRes::time;
+			$last_printed = monotime;
 		}
 	}
 
-	$time_elapsed = Time::HiRes::time - $begin;
+	$time_elapsed = monotime - $begin;
 	display_progress ($total_bytes_read, $source_size, $time_elapsed, \@rate_history);
 }
 
@@ -95,7 +98,7 @@ sub display_progress {
 	my @five_minute_rate;
 	my @one_minute_rate;
 	my @ten_second_rate;
-	my $now = Time::HiRes::time;
+	my $now = monotime;
 
 	for my $index (reverse 0 .. (scalar(@{$rate_history_reference})-1) ) {
 		my $row = ${$rate_history_reference}[$index];
@@ -151,7 +154,7 @@ sub display_progress {
 	}
 
 	print STDERR "    Transferred $printable_bytes_read" . $display_source_size . " (at average rate $display_transfer_rate)" . $display_estimated_time_remaining . "\n";
-	$last_printed = Time::HiRes::time;
+	$last_printed = monotime;
 }
 
 sub average_array {

--- a/perlpv
+++ b/perlpv
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 
-use Time::HiRes qw(clock_gettime CLOCK_MONOTONIC);
+use Time::HiRes qw(clock_gettime CLOCK_MONOTONIC alarm);
 
 # We need to turn off buffering of STDOUT to get rapid display of progress.
 STDOUT->autoflush(1);
@@ -48,39 +48,50 @@ sub transfer_data {
 	# in progress bar completion estimates.
 	my @rate_history;
 
+	my $alarmed = 0;
+
+	# Set up an alarm timer
+	local $SIG{'ALRM'} = sub {
+		$alarmed = 1;
+	};
+
+	alarm(0.5, 0.5);
+
 	# dump a clean newline in at the start, so we don't erase existing stuff in the terminal
 	print "\n";
 
+	my $timestamp_before_reading = monotime;
+	my $current_bytes_read = 0;
 	while ($returncode ne 0) {
-		# note the time before reading each source block
-		my $timestamp_before_reading = monotime;
-
 		$returncode = sysread (SOURCE, my $buffer, $blocksize);
-		$current_bytes_read = length($buffer);
-		$total_bytes_read += $current_bytes_read;
+		$current_bytes_read += length($buffer);
 
 		print TARGET $buffer
 	        	or die $! ? "Error writing to $TARGET: $!"
 			: "Exit status $? from $TARGET";
-		
-		# note the time after successfully writing each block
-		my $timestamp_after_writing = monotime;
 
-		# calculate transfer rate of this block
-		my $current_time_elapsed = $timestamp_after_writing - $timestamp_before_reading;
-		if ($current_time_elapsed eq 0) { $current_time_elapsed = 1; }
-		my $instantaneous_transfer_rate = ( $current_bytes_read / $current_time_elapsed );
+		if ($alarmed) {
+			my $timestamp_after_writing = monotime;
 
-		push (@rate_history,"$timestamp_after_writing,$instantaneous_transfer_rate");
+			$total_bytes_read += $current_bytes_read;
+			# calculate transfer rate of this block
+			my $current_time_elapsed = $timestamp_after_writing - $timestamp_before_reading;
+			if ($current_time_elapsed eq 0) { $current_time_elapsed = 1; }
+			my $instantaneous_transfer_rate = ( $current_bytes_read / $current_time_elapsed );
 
-		# updates visible progress twice per second
-		if ( ($timestamp_after_writing - $last_printed) >=0.5 ) { 
+			push (@rate_history,"$timestamp_after_writing,$instantaneous_transfer_rate");
+
 			my $time_elapsed = $timestamp_after_writing - $begin;
-			
+
 			display_progress ($total_bytes_read, $source_size, $time_elapsed, \@rate_history);
-			$last_printed = monotime;
+
+			$alarmed = 0;
+			$timestamp_before_reading = monotime;
+			$current_bytes_read = 0;
 		}
 	}
+
+	alarm(0);
 
 	$time_elapsed = monotime - $begin;
 	display_progress ($total_bytes_read, $source_size, $time_elapsed, \@rate_history);


### PR DESCRIPTION
Replace use of `Time::HiRes::time` with `Time::HiRes::clock_gettime(Time::HiRes::CLOCK_MONOTONIC)` - use of a monotonic clock to measure durations is important, as normal system time can change arbitrarily.

Set up a 0.5 second SIGALRM timer so most block copies only involve checking a single boolean variable instead of a timekeeping call.  This gives a modest bump in throughput, and a significant drop in user time consumed in my tests:

```
    Benchmark 1: ./perlpv testfile /dev/null
      Time (mean ± σ):      2.564 s ±  0.090 s    [User: 0.693 s, System: 1.870 s]
      Range (min … max):    2.382 s …  2.654 s    10 runs

    Benchmark 2: ./perlpv.orig testfile /dev/null
      Time (mean ± σ):      2.780 s ±  0.098 s    [User: 0.930 s, System: 1.850 s]
      Range (min … max):    2.600 s …  2.889 s    10 runs

    Summary
      './perlpv testfile /dev/null' ran
        1.08 ± 0.05 times faster than './perlpv.orig testfile /dev/null
```