### PR TITLE
Use syswrite and reuse buffer

### DIFF
--- a/perlpv
+++ b/perlpv
@@ -34,6 +34,21 @@ sub monotime {
 	clock_gettime(CLOCK_MONOTONIC)
 }
 
+sub full_syswrite {
+	my $file = shift;
+	my $buffer = shift;
+	my $length = shift;
+	my $written = 0;
+
+	while ($written < $length) {
+		my $res = syswrite($file, $buffer, $length - $written, $written);
+		defined($res) or return $res;
+		$written += $res;
+	}
+
+	1
+}
+
 sub transfer_data {
 	my $source_size = shift;
 
@@ -62,13 +77,21 @@ sub transfer_data {
 
 	my $timestamp_before_reading = monotime;
 	my $current_bytes_read = 0;
+	my $buffer;
 	while ($returncode ne 0) {
-		$returncode = sysread (SOURCE, my $buffer, $blocksize);
-		$current_bytes_read += length($buffer);
+		$returncode = sysread (SOURCE, $buffer, $blocksize);
 
-		print TARGET $buffer
+		unless (defined($returncode)) {
+			die "Error reading from $SOURCE: $!"
+		}
+
+		$current_bytes_read += $returncode;
+
+		full_syswrite(TARGET, $buffer, $returncode)
 	        	or die $! ? "Error writing to $TARGET: $!"
 			: "Exit status $? from $TARGET";
+
+		$buffer = '';
 
 		if ($alarmed || $returncode eq 0) {
 			my $timestamp_after_writing = monotime;

--- a/perlpv
+++ b/perlpv
@@ -1,6 +1,7 @@
 #!/usr/bin/perl
 
 use Time::HiRes qw(clock_gettime CLOCK_MONOTONIC alarm);
+use Errno (EINTR);
 
 # We need to turn off buffering of STDOUT to get rapid display of progress.
 STDOUT->autoflush(1);
@@ -34,7 +35,24 @@ sub monotime {
 	clock_gettime(CLOCK_MONOTONIC)
 }
 
-sub full_syswrite {
+# sysread wrapper that automatically handles EINTR
+sub safe_sysread {
+	my ($file, $length) = ($_[0], $_[2]);
+
+	while (1) {
+		my $res = sysread($file, $_[1], $length);
+
+		unless (defined($res)) {
+			$!{EINTR} and next;
+			return $res;
+		}
+
+		return $res;
+	}
+}
+
+# syswrite wrapper that automatically handles EINTR and short writes
+sub safe_syswrite {
 	my $file = shift;
 	my $buffer = shift;
 	my $length = shift;
@@ -42,7 +60,12 @@ sub full_syswrite {
 
 	while ($written < $length) {
 		my $res = syswrite($file, $buffer, $length - $written, $written);
-		defined($res) or return $res;
+
+		unless (defined($res)) {
+			$!{EINTR} and next;
+			return $res;
+		}
+
 		$written += $res;
 	}
 
@@ -77,9 +100,9 @@ sub transfer_data {
 
 	my $timestamp_before_reading = monotime;
 	my $current_bytes_read = 0;
-	my $buffer;
+	my $buffer = '';
 	while ($returncode ne 0) {
-		$returncode = sysread (SOURCE, $buffer, $blocksize);
+		$returncode = safe_sysread(SOURCE, $buffer, $blocksize);
 
 		unless (defined($returncode)) {
 			die "Error reading from $SOURCE: $!"
@@ -87,9 +110,11 @@ sub transfer_data {
 
 		$current_bytes_read += $returncode;
 
-		full_syswrite(TARGET, $buffer, $returncode)
-	        	or die $! ? "Error writing to $TARGET: $!"
-			: "Exit status $? from $TARGET";
+		if ($returncode) {
+			safe_syswrite(TARGET, $buffer, $returncode)
+				or die $! ? "Error writing to $TARGET: $!"
+				: "Exit status $? from $TARGET";
+		}
 
 		$buffer = '';
 

--- a/perlpv
+++ b/perlpv
@@ -70,7 +70,7 @@ sub transfer_data {
 	        	or die $! ? "Error writing to $TARGET: $!"
 			: "Exit status $? from $TARGET";
 
-		if ($alarmed) {
+		if ($alarmed || $returncode eq 0) {
 			my $timestamp_after_writing = monotime;
 
 			$total_bytes_read += $current_bytes_read;


### PR DESCRIPTION
Bypass Perl buffered IO for writes as well as reads, and have it reuse its buffer.

```
    Before:

    ❯ ./perlpv /dev/zero /dev/null
        Transferred 124.3GiB (at average rate 14.9GiB/sec)
    ^C
    11.778 real, 5.487 user, 6.290 sys;  page: 0 hard/1094 soft, swap: 0, I/O: 0/0

    ❯ ./perlpv testfile /dev/null
        Transferred 300.0GiB of 300.0GiB (at average rate 21.3GiB/sec)
    19.060 real, 5.117 user, 13.942 sys;  page: 0 hard/1093 soft, swap: 0, I/O: 0/0

    After:

    ❯ ./perlpv /dev/zero /dev/null
        Transferred 125.1GiB (at average rate 32.5GiB/sec)
    ^C
    5.980 real, 0.181 user, 5.798 sys;  page: 0 hard/1095 soft, swap: 0, I/O: 0/0

    ❯ ./perlpv testfile /dev/null
        Transferred 300.0GiB of 300.0GiB (at average rate 35.4GiB/sec)
    11.589 real, 0.425 user, 11.163 sys;  page: 0 hard/1100 soft, swap: 0, I/O: 0/0
```

And for comparison, pv:

```
❯ pv testfile >/dev/null
 300GiB 0:00:11 [25.9GiB/s] [======================================================>] 100%
11.567 real, 0.197 user, 11.369 sys;  page: 0 hard/247 soft, swap: 0, I/O: 0/0
```

Hopefully I got `full_syswrite` correct - I tested it with a GiB of random data but I dare say that was all full writes.